### PR TITLE
Audio Editor and Engine fixes - pitch and double stop

### DIFF
--- a/Roche-Engine/Audio/AudioEditor.cpp
+++ b/Roche-Engine/Audio/AudioEditor.cpp
@@ -61,8 +61,8 @@ void AudioEditor::SpawnSoundBankWindow(AudioType audioType)
 					if (audioType == SFX) {
 						if (ImGui::Checkbox(std::string("Random Pitch##").append(std::to_string(i)).append("random pitch").c_str(), &randomPitchEnabled)) {
 							m_vSoundFileInfo[i].randomPitch = !m_vSoundFileInfo[i].randomPitch;
+							randomPitchEnabled = !m_vSoundFileInfo[i].randomPitch;
 							AudioEngine::GetInstance()->SetRandomPitch(AudioEngine::GetInstance()->FindSoundBankFile(AudioEngine::GetInstance()->GetFileName(m_vSoundFileInfo[i].filePath), m_sActiveSoundBankName, audioType));
-
 						}
 
 						if (m_vSoundFileInfo[i].randomPitch) {

--- a/Roche-Engine/Audio/AudioEngine.cpp
+++ b/Roche-Engine/Audio/AudioEngine.cpp
@@ -305,15 +305,13 @@ HRESULT AudioEngine::StopMusic()
 {
 	HRESULT hr = S_OK;
 
-	for (int i = 0; m_vMusicSourceVoiceList.size() > i; i++) {
-		if (FAILED(hr = m_vMusicSourceVoiceList.at(i)->Stop(0))) {
+	while (m_vMusicSourceVoiceList.size() > 0) {
+		if (FAILED(hr = m_vMusicSourceVoiceList.at(0)->Stop(0))) {
 			ErrorLogger::Log(hr, "AudioEngine::StopMusic: Failed to Stop music");
 			return hr;
 		}
-		else {
-			m_vMusicSourceVoiceList.at(i)->DestroyVoice();
-			m_vMusicSourceVoiceList.erase(m_vMusicSourceVoiceList.begin() + i);
-		}
+		m_vMusicSourceVoiceList.at(0)->DestroyVoice();
+		m_vMusicSourceVoiceList.erase(m_vMusicSourceVoiceList.begin());
 	}
 
 	return hr;
@@ -366,11 +364,13 @@ void AudioEngine::UnloadAllAudio()
 void AudioEngine::StopAllAudio()
 {
 	while (m_vSFXSourceVoiceList.size() > 0) {
+		m_vSFXSourceVoiceList.at(0)->Stop(0);
 		m_vSFXSourceVoiceList.at(0)->DestroyVoice();
 		m_vSFXSourceVoiceList.erase(m_vSFXSourceVoiceList.begin());
 	}
 
 	while (m_vMusicSourceVoiceList.size() > 0) {
+		m_vMusicSourceVoiceList.at(0)->Stop(0);
 		m_vMusicSourceVoiceList.at(0)->DestroyVoice();
 		m_vMusicSourceVoiceList.erase(m_vMusicSourceVoiceList.begin());
 	}

--- a/Roche-Engine/Audio/AudioEngine.h
+++ b/Roche-Engine/Audio/AudioEngine.h
@@ -126,7 +126,7 @@ public:
 		m_pSFXSubmixVoice->SetVolume(m_fSFXVolume);
 	};
 	inline void SetDefaultVolume(std::shared_ptr<SoundBankFile> soundBank, float newVolume) { soundBank->volume = newVolume; };
-	inline void SetRandomPitch(std::shared_ptr<SoundBankFile> soundBank) { soundBank->randomPitch != soundBank->randomPitch; };
+	inline void SetRandomPitch(std::shared_ptr<SoundBankFile> soundBank) { soundBank->randomPitch = !soundBank->randomPitch; };
 	inline void SetPitchMin(std::shared_ptr<SoundBankFile> soundBank, float newPitchMin) { soundBank->pitchMin = newPitchMin; };
 	inline void SetPitchMax(std::shared_ptr<SoundBankFile> soundBank, float newPitchMax) { soundBank->pitchMax = newPitchMax; };
 


### PR DESCRIPTION
**Describe your changes**
Now the pitch in audio editor is updating correctly, additionally the stopping music works also correctly (doesn't have to pressed twice at times)

**Screenshots**
N/A

**Additional context**
N/A
